### PR TITLE
Initialize slope variable directly in rayCheck.

### DIFF
--- a/src/pathops/SkPathOpsWinding.cpp
+++ b/src/pathops/SkPathOpsWinding.cpp
@@ -138,9 +138,8 @@ void SkOpSegment::rayCheck(const SkOpRayHit& base, SkOpRayDir dir, SkOpRayHit** 
         if (base.fSpan->segment() == this && approximately_equal(base.fT, t)) {
             continue;
         }
-        SkDVector slope;
+        SkDVector slope = {0, 0};
         SkPoint pt;
-        PkDEBUGCODE(sk_bzero(&slope, sizeof(slope)));
         bool valid = false;
         if (approximately_zero(t)) {
             pt = fPts[0];


### PR DESCRIPTION
msvc 在debug模式下会默认开启/RTC1进行未初始化变量检查，程序在运行时检测到未初始化的变量会崩溃。
当前代码在t为0或1的时候不会初始化slope，导致在某些文档下崩溃。